### PR TITLE
fix example application

### DIFF
--- a/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/example/SecuredResource.java
+++ b/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/example/SecuredResource.java
@@ -32,7 +32,7 @@ public class SecuredResource {
         final JsonWebToken token = JsonWebToken.builder()
                 .header(JsonWebTokenHeader.HS512())
                 .claim(JsonWebTokenClaim.builder()
-                        .param("principal", "good-guy")
+                        .subject("good-guy")
                         .issuedAt(new DateTime().plusHours(1))
                         .build())
                 .build();


### PR DESCRIPTION
ExampleAuthenticator is looking for "good-guy" in the subject field, but we were putting it in a field with the key "principal".