### PR TITLE
JWTAuthFilter will (if configured to do so) look through the cookies …

### DIFF
--- a/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/AuthBaseTest.java
+++ b/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/AuthBaseTest.java
@@ -25,6 +25,7 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     protected static final String ORDINARY_USER = "ordinary-guy";
     protected static final String BADGUY_USER = "bad-guy";
     protected static final String BEARER_PREFIX = "Bearer";
+    protected static final String COOKIE_NAME = "jwt-token";
 
     static {
         BootstrapLogging.bootstrap();
@@ -133,6 +134,14 @@ public abstract class AuthBaseTest<T extends DropwizardResourceConfig> extends J
     public void transformsCredentialsToPrincipals() throws Exception {
         assertThat(target("/test/admin").request()
                 .header(HttpHeaders.AUTHORIZATION, getPrefix() + " " + getGoodGuyValidToken())
+                .get(String.class))
+                .isEqualTo("'" + ADMIN_USER + "' has admin privileges");
+    }
+
+    @Test
+    public void transformsCredentialsToPrincipalsWithCookie() throws Exception {
+        assertThat(target("/test/admin").request()
+                .cookie(COOKIE_NAME, getGoodGuyValidToken())
                 .get(String.class))
                 .isEqualTo("'" + ADMIN_USER + "' has admin privileges");
     }

--- a/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/JWTAuthProviderTest.java
+++ b/src/test/java/com/github/toastshaman/dropwizard/auth/jwt/JWTAuthProviderTest.java
@@ -26,6 +26,7 @@ public class JWTAuthProviderTest extends AuthBaseTest<JWTAuthProviderTest.JWTAut
     public static class JWTAuthTestResourceConfig extends AuthBaseResourceConfig {
         protected ContainerRequestFilter getAuthFilter() {
             return new JWTAuthFilter.Builder<>()
+                    .setCookieName(COOKIE_NAME)
                     .setTokenParser(new DefaultJsonWebTokenParser())
                     .setTokenVerifier(new HmacSHA512Verifier(SECRET_KEY))
                     .setPrefix(BEARER_PREFIX)


### PR DESCRIPTION
This enables tokens to be submitted using cookies (especially useful for serving images).  

What do you think? 