### PR TITLE
Update jose4j version to 0.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.5.2</version>
+            <version>0.5.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Upgraded the Jose4J dependency to 0.5.5. I'm not sure if the dropwizard-auth-jwt offers any JWE capabilities (the main reason to upgrade - see http://blog.intothesymmetry.com/2017/03/critical-vulnerability-in-json-web.html) - so the need to upgrade is less urgent than I thought