### PR TITLE
Add debug logging if no valid token received

### DIFF
--- a/src/main/java/com/github/toastshaman/dropwizard/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/github/toastshaman/dropwizard/auth/jwt/JwtAuthFilter.java
@@ -79,6 +79,8 @@ public class JwtAuthFilter<P extends Principal> extends AuthFilter<JwtContext, P
                 LOGGER.warn("Error authenticating credentials", ex);
                 throw new InternalServerErrorException();
             }
+        } else {
+            LOGGER.debug("No valid token received");
         }
 
         throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));


### PR DESCRIPTION
Not sure if this is a good idea or not. We recently had an issue where a client of our Dropwizard/JWT app was getting an un-authenticated response and no clues in the app logs as to  why. We had to help debug whereas it would be nice if they could just enable debug logging to get more of an idea what was happening, to resolve it themselves

(They had forgotten to put Bearer in the header!!!)